### PR TITLE
python 3 compatible

### DIFF
--- a/bin/odps
+++ b/bin/odps
@@ -1,0 +1,33 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+my $conf = shift @ARGV;
+my $method = shift @ARGV;
+my $uri = shift @ARGV;
+$uri =~ s/^\/+//; # remove leading slash
+
+unless (defined($conf) and defined($method) and defined($uri)) {
+    print "usage: $0 conf method uri\n";
+    print "   eg: $0 odps_config.ini get /projects/odpsdemo/tables\n";
+    exit 1;
+}
+
+my $access_id;
+my $access_key;
+my $endpoint;
+open CONF, "<", $conf or die "$!\n";
+while (<CONF>) {
+    chomp;
+    $access_id = $1 if m/^access_id\s*=\s*(\S+)$/;
+    $access_key = $1 if m/^access_key\s*=\s*(\S+)$/;
+    $endpoint = $1 if m/^end_point\s*=\s*(\S+)$/;
+}
+close CONF;
+
+die "invalid odps config file\n" unless (defined($access_id) and defined($access_key) and defined($endpoint));
+$endpoint =~ s/\/+$//; # remove trailing slash
+
+# print "/usr/bin/http -v --auth-type=odps --auth='$access_id:$access_key' GET $endpoint/$uri\n";
+exec("/usr/bin/http -v --auth-type=odps --auth='$access_id:$access_key' GET $endpoint/$uri");

--- a/httpie_hmac_auth.py
+++ b/httpie_hmac_auth.py
@@ -11,9 +11,12 @@ import urllib
 from httpie.plugins import AuthPlugin
 
 try:
-    import urlparse
+    from urlparse import urlparse
+    from urllib import unquote
+
 except ImportError:
-    import urllib.parse
+    from urllib.parse import urlparse
+    from urllib.parse import unquote
 
 __version__ = '0.2.0'
 __author__ = 'Nick Satterly'
@@ -21,9 +24,9 @@ __licence__ = 'MIT'
 
 
 class HmacAuth:
-    def __init__(self, access_key, secret_key):
-        self.access_key = access_key
-        self.secret_key = secret_key.encode('ascii')
+    def __init__(self, username, password):
+        self.access_id = username
+        self.access_key = password.encode('ascii')
 
     def __call__(self, r):
 
@@ -49,36 +52,41 @@ class HmacAuth:
             httpdate = now.strftime('%a, %d %b %Y %H:%M:%S GMT')
             r.headers['Date'] = httpdate
 
-        url = urlparse.urlparse(r.url)
+        url = urlparse(r.url)
 
         netloc = url.netloc
         pos = r.url.index(netloc) + len(netloc)
         path = r.url[pos:]
 
-        path = urllib.unquote(path).decode('utf8')
+        path = unquote(path)
+        if isinstance(path, bytes):
+            path = path.decode('utf8')
         if path.startswith('/api'):
             path = path[4:]
 
         string_to_sign = '\n'.join([method, content_md5, content_type, httpdate, path])
-
-        digest = hmac.new(self.secret_key, string_to_sign, hashlib.sha1).digest()
+        if not isinstance(string_to_sign, bytes):
+            string_to_sign = string_to_sign.encode('utf-8')
+        digest = hmac.new(self.access_key, string_to_sign, hashlib.sha1).digest()
         signature = base64.encodestring(digest).rstrip()
+        if isinstance(signature, bytes):
+            signature = signature.decode('utf-8')
 
-        if self.access_key == '':
+        if self.access_id == '':
             r.headers['Authorization'] = 'ODPS %s' % signature
-        elif self.secret_key == '':
+        elif self.access_key == '':
             raise ValueError('HMAC secret key cannot be empty.')
         else:
-            r.headers['Authorization'] = 'ODPS %s:%s' % (self.access_key, signature)
+            r.headers['Authorization'] = 'ODPS %s:%s' % (self.access_id, signature)
 
         return r
 
 
 class HmacAuthPlugin(AuthPlugin):
 
-    name = 'HMAC token auth'
-    auth_type = 'hmac'
-    description = 'Sign requests using a HMAC authentication method like AWS'
+    name = 'ODPS token auth'
+    auth_type = 'odps'
+    description = 'Sign requests using a ODPS compliant method'
 
-    def get_auth(self, access_key, secret_key):
-        return HmacAuth(access_key, secret_key)
+    def get_auth(self, username, password):
+        return HmacAuth(username, password)

--- a/httpie_odps_auth.py
+++ b/httpie_odps_auth.py
@@ -18,12 +18,12 @@ except ImportError:
     from urllib.parse import urlparse
     from urllib.parse import unquote
 
-__version__ = '0.2.0'
-__author__ = 'Nick Satterly'
+__version__ = '0.2.1'
+__author__ = 'onesuper'
 __licence__ = 'MIT'
 
 
-class HmacAuth:
+class OdpsAuth:
     def __init__(self, username, password):
         self.access_id = username
         self.access_key = password.encode('ascii')
@@ -75,18 +75,18 @@ class HmacAuth:
         if self.access_id == '':
             r.headers['Authorization'] = 'ODPS %s' % signature
         elif self.access_key == '':
-            raise ValueError('HMAC secret key cannot be empty.')
+            raise ValueError('Access key cannot be empty.')
         else:
             r.headers['Authorization'] = 'ODPS %s:%s' % (self.access_id, signature)
 
         return r
 
 
-class HmacAuthPlugin(AuthPlugin):
+class OdpsAuthPlugin(AuthPlugin):
 
     name = 'ODPS token auth'
     auth_type = 'odps'
     description = 'Sign requests using a ODPS compliant method'
 
     def get_auth(self, username, password):
-        return HmacAuth(username, password)
+        return OdpsAuth(username, password)

--- a/setup.py
+++ b/setup.py
@@ -5,20 +5,20 @@ except ImportError:
     pass
 
 setup(
-    name='httpie-hmac-auth',
-    description='HMAC Auth plugin for HTTPie.',
+    name='httpie-odps-auth',
+    description='ODPS Auth plugin for HTTPie.',
     long_description=open('README.md').read().strip(),
-    version='0.2.0',
-    author='Nick Satterly',
-    author_email='nick.satterly@theguardian.com',
+    version='0.2.1',
+    author='Cheng YiChao',
+    author_email='onesuperclark@gmail.com',
     license='MIT',
-    url='https://github.com/guardian/httpie-hmac-auth',
-    download_url='https://github.com/guardian/httpie-hmac-auth',
-    py_modules=['httpie_hmac_auth'],
+    url='https://github.com/onesuper/httpie-hmac-auth',
+    download_url='https://github.com/onesuper/httpie-hmac-auth',
+    py_modules=['httpie_odps_auth'],
     zip_safe=False,
     entry_points={
         'httpie.plugins.auth.v1': [
-            'httpie_hmac_auth = httpie_hmac_auth:HmacAuthPlugin'
+            'httpie_odps_auth = httpie_odps_auth:OdpsAuthPlugin'
         ]
     },
     install_requires=[


### PR DESCRIPTION
- python 3 compatible (actually python2 not well tested)
- rename to httipe odps auth (better rename repo to httpie-odps-auth as well)
- add a startup script to handle odps_config.ini
